### PR TITLE
0.1.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,6 @@ allprojects {
         google()
         mavenCentral()
         maven {
-            url = uri("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven")
-            content {
-                includeGroup("org.jetbrains.kotlinx")
-            }
-        }
-        maven {
             url = uri("https://maven.pkg.github.com/hirogakatageri/core")
             credentials {
                 username = System.getenv("GITHUB_USER")

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -11,7 +11,7 @@ object Constants {
 
     //Kotlin
     const val KOTLIN_VERSION = "1.4.32"
-    const val COROUTINES_VERSION = "1.4.2"
+    const val COROUTINES_VERSION = "1.4.3"
 
     //Android
     const val LIFECYCLE_VERSION = "2.3.0"

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -3,8 +3,8 @@ object Constants {
     const val MIN_SDK_VERSION = 23
     const val COMPILE_SDK_VERSION = 30
     const val TARGET_SDK_VERSION = 30
-    const val VERSION_CODE = 4
-    const val VERSION_NAME = "0.1.3"
+    const val VERSION_CODE = 5
+    const val VERSION_NAME = "0.1.4"
 
     //Google
     const val GOOGLE_SERVICES_VERSION = "4.3.4"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -67,15 +67,14 @@ dependencies {
     implementation(Constants.COROUTINES)
     implementation(Constants.COROUTINES_ANDROID)
     testImplementation(Constants.COROUTINES_TEST)
-    androidTestImplementation(Constants.COROUTINES_TEST)
 
     implementation(Constants.TIMBERKT)
 
-    implementation(Constants.KOIN_ANDROID)
-    implementation(Constants.KOIN_ANDROID_SCOPE)
-    implementation(Constants.KOIN_ANDROID_VIEWMODEL)
-    implementation(Constants.KOIN_ANDROID_FRAGMENT)
-    implementation(Constants.KOIN_ANDROID_EXT)
+    api(Constants.KOIN_ANDROID)
+    api(Constants.KOIN_ANDROID_SCOPE)
+    api(Constants.KOIN_ANDROID_VIEWMODEL)
+    api(Constants.KOIN_ANDROID_FRAGMENT)
+    api(Constants.KOIN_ANDROID_EXT)
     testImplementation(Constants.KOIN_TEST)
 
     testImplementation(Constants.JUNIT)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
     implementation(Constants.COROUTINES)
     implementation(Constants.COROUTINES_ANDROID)
     testImplementation(Constants.COROUTINES_TEST)
-    androidTestImplementation(Constants.COROUTINES_TEST)
 
     // Android
     implementation(Constants.APPCOMPAT)
@@ -59,25 +58,10 @@ dependencies {
     implementation(Constants.CONSTRAINT_LAYOUT)
 
     implementation(Constants.ANDROID_KTX_CORE)
-    implementation(Constants.ANDROID_KTX_ACTIVITY)
-    implementation(Constants.ANDROID_KTX_FRAGMENT)
-
-    implementation(Constants.ANDROID_LIVEDATA)
-    implementation(Constants.ANDROID_VIEWMODEL)
-    implementation(Constants.ANDROID_STATE_VIEWMODEL)
-    implementation(Constants.ANDROID_LIFECYCLE_SERVICE)
 
     implementation(Constants.NAVIGATION_FRAGMENT)
     implementation(Constants.NAVIGATION_UI)
     androidTestImplementation(Constants.NAVIGATION_TESTING)
-
-    // DI
-    implementation(Constants.KOIN_ANDROID)
-    implementation(Constants.KOIN_ANDROID_SCOPE)
-    implementation(Constants.KOIN_ANDROID_VIEWMODEL)
-    implementation(Constants.KOIN_ANDROID_FRAGMENT)
-    implementation(Constants.KOIN_ANDROID_EXT)
-    testImplementation(Constants.KOIN_TEST)
 
     // Core
     implementation(Constants.DATE_TIME)


### PR DESCRIPTION
- Optimized dependencies of the Sample Module.
- Added KTX Activity and Fragment to Core to avoid an issue where ```registerForActivityResult``` is missing in Fragments.